### PR TITLE
Added lead time disclosure in Lesson 3 brief

### DIFF
--- a/src/imsim/services/training.py
+++ b/src/imsim/services/training.py
@@ -217,6 +217,8 @@ LESSON_DEFINITIONS: tuple[LevelDefinition, ...] = (
             "Fill rate is a customer-service measurement, not an inventory quantity.",
             "A partially filled stock line counts as missed service in this model.",
             "Use a guided reorder to protect upcoming customer lines before stock runs out.",
+            "A guided reorder creates inbound supply first; on-hand inventory only increases "
+            "after the simulated lead time passes.",
         ),
         locked_features=(
             "Custom quantities remain locked until later ordering lessons.",

--- a/src/imsim/services/training.py
+++ b/src/imsim/services/training.py
@@ -218,7 +218,7 @@ LESSON_DEFINITIONS: tuple[LevelDefinition, ...] = (
             "A partially filled stock line counts as missed service in this model.",
             "Use a guided reorder to protect upcoming customer lines before stock runs out.",
             "A guided reorder creates inbound supply first; on-hand inventory only increases "
-            "after the simulated lead time passes.",
+            "after the simulated lead time passes and the order is received.",
         ),
         locked_features=(
             "Custom quantities remain locked until later ordering lessons.",


### PR DESCRIPTION
#31 Added additional bullet point in brief, "A guided reorder creates inbound supply first; on-hand inventory only increases after the simulated lead time passes."