### PR TITLE
Fix Level 13 Objectives and Polish Planner Grid UI

### DIFF
--- a/assets/imsim.css
+++ b/assets/imsim.css
@@ -2055,6 +2055,14 @@ body {
     height: 100%;
   }
 
+  .dashboard-shell.lesson-dashboard #inventory-panel {
+    align-self: start;
+  }
+
+  .dashboard-shell.lesson-dashboard #inventory-panel > .card {
+    height: auto;
+  }
+
   .dashboard-shell.lesson-layout-workspace-basic #inventory-panel .card-body,
   .dashboard-shell.lesson-layout-workspace-signal #inventory-panel .card-body {
     display: flex;

--- a/assets/imsim.css
+++ b/assets/imsim.css
@@ -1777,6 +1777,16 @@ body {
     width: 100%;
   }
 
+  .dashboard-shell.simulator-dashboard .dashboard-insights-row,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-insights-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    width: 100%;
+    align-items: stretch;
+    margin-bottom: 0.75rem !important;
+  }
+
   .dashboard-shell.lesson-dashboard .dashboard-insights-row > [id],
   .dashboard-shell.lesson-dashboard .dashboard-detail-row > [id],
   .dashboard-shell.simulator-dashboard .dashboard-insights-row > [id],
@@ -1784,7 +1794,9 @@ body {
     display: flex;
   }
 
+  .dashboard-shell.simulator-dashboard .dashboard-insights-row > [id],
   .dashboard-shell.simulator-dashboard .dashboard-detail-row > [id],
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-insights-row > [id],
   .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-detail-row > [id] {
     width: 100% !important;
     max-width: none !important;
@@ -1796,6 +1808,7 @@ body {
   .dashboard-shell.simulator-dashboard .dashboard-insights-row > [id] > .card,
   .dashboard-shell.simulator-dashboard .dashboard-detail-row > [id] > .card {
     width: 100%;
+    height: 100%;
   }
 
   .dashboard-shell.simulator-dashboard #exceptions-panel > .card,
@@ -2254,7 +2267,7 @@ body {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 0.75rem;
-    margin-bottom: 0.3rem !important;
+    margin-bottom: 0.75rem !important;
   }
 
   .dashboard-shell.lesson-layout-workspace-advanced .dashboard-detail-row {

--- a/assets/imsim.css
+++ b/assets/imsim.css
@@ -1717,6 +1717,16 @@ body {
     align-items: start;
   }
 
+  .dashboard-shell.simulator-dashboard .dashboard-main-layout,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-main-layout {
+    display: grid;
+    grid-template-columns:
+      minmax(17rem, var(--imsim-size-dashboard-rail-max))
+      minmax(0, 1fr);
+    gap: 0.75rem;
+    width: 100%;
+  }
+
   .dashboard-shell.lesson-dashboard .dashboard-rail-column,
   .dashboard-shell.lesson-dashboard .dashboard-main-column,
   .dashboard-shell.simulator-dashboard .dashboard-rail-column,
@@ -1737,6 +1747,15 @@ body {
     overflow: visible;
   }
 
+  .dashboard-shell.simulator-dashboard .dashboard-rail-column,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-rail-column,
+  .dashboard-shell.simulator-dashboard .dashboard-main-column,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-main-column {
+    width: 100% !important;
+    max-width: none !important;
+    padding: 0;
+  }
+
   .dashboard-shell.lesson-dashboard #graph-panel,
   .dashboard-shell.simulator-dashboard #graph-panel {
     flex: 1 1 auto;
@@ -1750,11 +1769,26 @@ body {
     flex: 0 0 auto;
   }
 
+  .dashboard-shell.simulator-dashboard .dashboard-detail-row,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-detail-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem;
+    width: 100%;
+  }
+
   .dashboard-shell.lesson-dashboard .dashboard-insights-row > [id],
   .dashboard-shell.lesson-dashboard .dashboard-detail-row > [id],
   .dashboard-shell.simulator-dashboard .dashboard-insights-row > [id],
   .dashboard-shell.simulator-dashboard .dashboard-detail-row > [id] {
     display: flex;
+  }
+
+  .dashboard-shell.simulator-dashboard .dashboard-detail-row > [id],
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification .dashboard-detail-row > [id] {
+    width: 100% !important;
+    max-width: none !important;
+    padding: 0;
   }
 
   .dashboard-shell.lesson-dashboard .dashboard-insights-row > [id] > .card,
@@ -1764,6 +1798,11 @@ body {
     width: 100%;
   }
 
+  .dashboard-shell.simulator-dashboard #exceptions-panel > .card,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification #exceptions-panel > .card {
+    height: auto;
+  }
+
   .dashboard-shell.lesson-dashboard #inventory-panel .card-body,
   .dashboard-shell.simulator-dashboard #inventory-panel .card-body,
   .dashboard-shell.simulator-dashboard #exceptions-panel .card-body {
@@ -1771,6 +1810,12 @@ body {
     flex-direction: column;
     max-height: none;
     min-height: 0;
+  }
+
+  .dashboard-shell.simulator-dashboard #exceptions-panel .card-body,
+  .dashboard-shell.lesson-dashboard.lesson-layout-workspace-certification #exceptions-panel .card-body {
+    max-height: 14rem;
+    overflow-y: auto;
   }
 
   .dashboard-shell.lesson-dashboard #inventory-table-shell,
@@ -2220,7 +2265,7 @@ body {
 
   .dashboard-shell.lesson-layout-workspace-certification .dashboard-detail-row {
     display: grid;
-    grid-template-columns: minmax(0, 1.8fr) minmax(18rem, 1fr);
+    grid-template-columns: minmax(0, 1fr);
     gap: 0.75rem;
   }
 
@@ -2259,10 +2304,13 @@ body {
   }
 
   .dashboard-shell.lesson-layout-workspace-advanced #inventory-panel .card-body,
-  .dashboard-shell.lesson-layout-workspace-certification #inventory-panel .card-body,
-  .dashboard-shell.lesson-layout-workspace-certification #exceptions-panel .card-body {
+  .dashboard-shell.lesson-layout-workspace-certification #inventory-panel .card-body {
     min-height: 0;
     max-height: none;
+  }
+
+  .dashboard-shell.lesson-layout-workspace-certification #exceptions-panel .card-body {
+    min-height: 0;
   }
 
   .dashboard-shell.lesson-layout-workspace-advanced #inventory-panel .card-body,

--- a/src/imsim/app.py
+++ b/src/imsim/app.py
@@ -122,7 +122,7 @@ def create_app(config: IMSimConfig | None = None) -> dash.Dash:
             state.is_initialized = False
             try:
                 repository.save(session_id, state)
-            except (InvalidSessionIdError, SessionConflictError):
+            except InvalidSessionIdError, SessionConflictError:
                 continue
             response = jsonify({"ok": True, "paused": True})
             response.headers["Cache-Control"] = "no-store"

--- a/src/imsim/app.py
+++ b/src/imsim/app.py
@@ -121,7 +121,7 @@ def create_app(config: IMSimConfig | None = None) -> dash.Dash:
             state.is_initialized = False
             try:
                 repository.save(session_id, state)
-            except InvalidSessionIdError, SessionConflictError:
+            except (InvalidSessionIdError, SessionConflictError):
                 continue
             response = jsonify({"ok": True, "paused": True})
             response.headers["Cache-Control"] = "no-store"

--- a/src/imsim/callbacks/inventory.py
+++ b/src/imsim/callbacks/inventory.py
@@ -339,9 +339,10 @@ def register_inventory_callbacks(ctx: CallbackRegistrarContext) -> None:
         if not state.items or not is_action_allowed(state, "guided_po"):
             raise PreventUpdate
         below_op = any(item.pna <= item.op for item in state.items)
+        below_lp_count = sum(1 for item in state.items if item.pna < item.lp)
         summary = place_purchase_orders(state)
         if summary["lines"] > 0:
-            record_guided_order(state, below_op=below_op)
+            record_guided_order(state, below_op=below_op, below_lp_count=below_lp_count)
         ctx.persist_state(session_id, state)
         return ctx.next_session_revision(session_revision)
 

--- a/src/imsim/callbacks/inventory.py
+++ b/src/imsim/callbacks/inventory.py
@@ -338,11 +338,17 @@ def register_inventory_callbacks(ctx: CallbackRegistrarContext) -> None:
         session_id, state = ctx.require_session(client_data)
         if not state.items or not is_action_allowed(state, "guided_po"):
             raise PreventUpdate
-        below_op = any(item.pna <= item.op for item in state.items)
+        below_op_count = sum(1 for item in state.items if item.pna < item.op)
+        below_op = below_op_count > 0
         below_lp_count = sum(1 for item in state.items if item.pna < item.lp)
         summary = place_purchase_orders(state)
         if summary["lines"] > 0:
-            record_guided_order(state, below_op=below_op, below_lp_count=below_lp_count)
+            record_guided_order(
+                state,
+                below_op=below_op,
+                below_op_count=below_op_count,
+                below_lp_count=below_lp_count,
+            )
         ctx.persist_state(session_id, state)
         return ctx.next_session_revision(session_revision)
 

--- a/src/imsim/models.py
+++ b/src/imsim/models.py
@@ -298,6 +298,7 @@ class TrainingProfile:
     last_result_message: str = ""
     guided_orders_placed: int = 0
     guided_orders_below_op: int = 0
+    guided_orders_below_lp: int = 0
     custom_orders_placed: int = 0
     parameter_updates_applied: int = 0
 
@@ -388,6 +389,7 @@ class TrainingProfile:
             last_result_message=str(data.get("last_result_message", "")),
             guided_orders_placed=max(0, int(data.get("guided_orders_placed", 0))),
             guided_orders_below_op=max(0, int(data.get("guided_orders_below_op", 0))),
+            guided_orders_below_lp=max(0, int(data.get("guided_orders_below_lp", 0))),
             custom_orders_placed=max(0, int(data.get("custom_orders_placed", 0))),
             parameter_updates_applied=max(0, int(data.get("parameter_updates_applied", 0))),
         )

--- a/src/imsim/performance.py
+++ b/src/imsim/performance.py
@@ -298,9 +298,10 @@ class _VirtualUser:
             return
         if is_action_allowed(state, "guided_po"):
             below_op = any(item.pna < item.op for item in state.items)
+            below_lp_count = sum(1 for item in state.items if item.pna < item.lp)
             summary = place_purchase_orders(state)
             if int(summary["lines"]) > 0:
-                record_guided_order(state, below_op=below_op)
+                record_guided_order(state, below_op=below_op, below_lp_count=below_lp_count)
         if is_action_allowed(state, "custom_order"):
             quantities = [item.soq for item in state.items]
             if place_custom_orders(state, quantities):

--- a/src/imsim/performance.py
+++ b/src/imsim/performance.py
@@ -297,11 +297,17 @@ class _VirtualUser:
         if level is None:
             return
         if is_action_allowed(state, "guided_po"):
-            below_op = any(item.pna < item.op for item in state.items)
+            below_op_count = sum(1 for item in state.items if item.pna < item.op)
+            below_op = below_op_count > 0
             below_lp_count = sum(1 for item in state.items if item.pna < item.lp)
             summary = place_purchase_orders(state)
             if int(summary["lines"]) > 0:
-                record_guided_order(state, below_op=below_op, below_lp_count=below_lp_count)
+                record_guided_order(
+                    state,
+                    below_op=below_op,
+                    below_op_count=below_op_count,
+                    below_lp_count=below_lp_count,
+                )
         if is_action_allowed(state, "custom_order"):
             quantities = [item.soq for item in state.items]
             if place_custom_orders(state, quantities):

--- a/src/imsim/repository.py
+++ b/src/imsim/repository.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import tempfile
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import RLock
@@ -26,6 +27,8 @@ class InvalidSessionIdError(ValueError):
 
 
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+_WINDOWS_REPLACE_ATTEMPTS = 5
+_WINDOWS_REPLACE_RETRY_DELAY_SECONDS = 0.05
 
 
 def normalize_session_id(session_id: str) -> str:
@@ -145,10 +148,20 @@ class FileSessionRepository:
                 handle.flush()
                 os.fsync(handle.fileno())
                 tmp_path = Path(handle.name)
-            os.replace(tmp_path, path)
+            self._replace_path(tmp_path, path)
         finally:
             if tmp_path is not None and tmp_path.exists():
                 tmp_path.unlink(missing_ok=True)
+
+    def _replace_path(self, source: Path, target: Path) -> None:
+        for attempt in range(_WINDOWS_REPLACE_ATTEMPTS):
+            try:
+                os.replace(source, target)
+                return
+            except PermissionError:
+                if attempt == _WINDOWS_REPLACE_ATTEMPTS - 1:
+                    raise
+                time.sleep(_WINDOWS_REPLACE_RETRY_DELAY_SECONDS)
 
 
 class DatabaseSessionRepository:

--- a/src/imsim/services/training.py
+++ b/src/imsim/services/training.py
@@ -552,7 +552,7 @@ LESSON_DEFINITIONS: tuple[LevelDefinition, ...] = (
             "PO overview controls unlock after the line-point lesson.",
         ),
         demand_mode="deterministic",
-        day_window=14,
+        day_window=40,
         scenario=(
             _item(60, 18, 40, 60, safety_allowance_pct=20, standard_pack=5, hits_per_month=18),
             _item(45, 15, 22, 42, safety_allowance_pct=20, standard_pack=5, hits_per_month=12),
@@ -561,7 +561,7 @@ LESSON_DEFINITIONS: tuple[LevelDefinition, ...] = (
         visible_panels=frozenset({"graph", "service", "inventory", "session", "actions"}),
         visible_columns=("item", "pna", "op", "lp", "usage_rate", "soq"),
         allowed_actions=frozenset({"guided_po"}),
-        win_conditions={"guided_order_min": 1, "below_lp_min": 2},
+        win_conditions={"guided_order_below_lp_item_min": 2, "guided_order_below_lp_min": 2},
         global_settings=_settings(r_cycle=14),
         layout_variant="workspace_signal",
         teaching_goal="Show that the trigger item is not the only item to buy.",
@@ -959,6 +959,14 @@ def _progress_metric_rows(state: SimulationState, level: LevelDefinition) -> tup
     if "guided_order_min" in level.win_conditions:
         needed = int(level.win_conditions["guided_order_min"])
         rows.append(f"Guided reorders used: {state.training.guided_orders_placed}/{needed}")
+    if "guided_order_below_lp_min" in level.win_conditions:
+        needed_items = int(level.win_conditions.get("guided_order_below_lp_item_min", 2))
+        needed_orders = int(level.win_conditions["guided_order_below_lp_min"])
+        rows.append(
+            "Guided reorders while "
+            f"{needed_items}+ items below LP: {state.training.guided_orders_below_lp}/"
+            f"{needed_orders}"
+        )
     if "on_order_min" in level.win_conditions:
         target = float(level.win_conditions["on_order_min"])
         on_order_total = sum(sum(receipt.qty for receipt in item.pipeline) for item in state.items)
@@ -1034,6 +1042,11 @@ def evaluate_active_lesson(state: SimulationState) -> LessonEvaluation | None:
     if "guided_order_min" in level.win_conditions:
         checks.append(
             state.training.guided_orders_placed >= int(level.win_conditions["guided_order_min"])
+        )
+    if "guided_order_below_lp_min" in level.win_conditions:
+        checks.append(
+            state.training.guided_orders_below_lp
+            >= int(level.win_conditions["guided_order_below_lp_min"])
         )
     if "on_order_min" in level.win_conditions:
         on_order_total = sum(sum(receipt.qty for receipt in item.pipeline) for item in state.items)
@@ -1126,10 +1139,17 @@ def apply_lesson_evaluation(
     return evaluation
 
 
-def record_guided_order(state: SimulationState, *, below_op: bool = False) -> None:
+def record_guided_order(
+    state: SimulationState, *, below_op: bool = False, below_lp_count: int = 0
+) -> None:
     state.training.guided_orders_placed += 1
     if below_op:
         state.training.guided_orders_below_op += 1
+    level = active_level(state)
+    if level is not None and "guided_order_below_lp_min" in level.win_conditions:
+        needed = int(level.win_conditions.get("guided_order_below_lp_item_min", 2))
+        if below_lp_count >= needed:
+            state.training.guided_orders_below_lp += 1
 
 
 def record_custom_order(state: SimulationState) -> None:
@@ -1181,6 +1201,7 @@ def build_level_state(level_id: str, profile: TrainingProfile | None = None) -> 
     progress.last_result_message = ""
     progress.guided_orders_placed = 0
     progress.guided_orders_below_op = 0
+    progress.guided_orders_below_lp = 0
     progress.custom_orders_placed = 0
     progress.parameter_updates_applied = 0
     return _state_for_scenario(
@@ -1198,6 +1219,7 @@ def build_simulator_state(profile: TrainingProfile | None = None) -> SimulationS
     progress.last_result_message = ""
     progress.guided_orders_placed = 0
     progress.guided_orders_below_op = 0
+    progress.guided_orders_below_lp = 0
     progress.custom_orders_placed = 0
     progress.parameter_updates_applied = 0
     certification = final_academy_level()

--- a/src/imsim/services/training.py
+++ b/src/imsim/services/training.py
@@ -569,9 +569,13 @@ LESSON_DEFINITIONS: tuple[LevelDefinition, ...] = (
             _item(30, 20, 75, 38, safety_allowance_pct=25, standard_pack=1, hits_per_month=7),
         ),
         visible_panels=frozenset({"graph", "service", "inventory", "session", "actions"}),
-        visible_columns=("item", "pna", "op", "lp", "usage_rate", "soq"),
+        visible_columns=("item", "pna", "op", "lp", "days_to_op", "soq"),
         allowed_actions=frozenset({"guided_po"}),
-        win_conditions={"guided_order_below_lp_item_min": 2, "guided_order_below_lp_min": 2},
+        win_conditions={
+            "guided_order_below_op_item_min": 1,
+            "guided_order_below_lp_item_min": 3,
+            "guided_order_below_lp_min": 2,
+        },
         global_settings=_settings(r_cycle=14),
         layout_variant="workspace_signal",
         teaching_goal="Show that the trigger item is not the only item to buy.",
@@ -970,11 +974,12 @@ def _progress_metric_rows(state: SimulationState, level: LevelDefinition) -> tup
         needed = int(level.win_conditions["guided_order_min"])
         rows.append(f"Guided reorders used: {state.training.guided_orders_placed}/{needed}")
     if "guided_order_below_lp_min" in level.win_conditions:
+        needed_op_items = int(level.win_conditions.get("guided_order_below_op_item_min", 0))
         needed_items = int(level.win_conditions.get("guided_order_below_lp_item_min", 2))
         needed_orders = int(level.win_conditions["guided_order_below_lp_min"])
         rows.append(
-            "Guided reorders while "
-            f"{needed_items}+ items below LP: {state.training.guided_orders_below_lp}/"
+            f"Guided reorders while {needed_op_items}+ item below OP and "
+            f"{needed_items}+ total below LP: {state.training.guided_orders_below_lp}/"
             f"{needed_orders}"
         )
     if "on_order_min" in level.win_conditions:
@@ -1150,15 +1155,20 @@ def apply_lesson_evaluation(
 
 
 def record_guided_order(
-    state: SimulationState, *, below_op: bool = False, below_lp_count: int = 0
+    state: SimulationState,
+    *,
+    below_op: bool = False,
+    below_op_count: int = 0,
+    below_lp_count: int = 0,
 ) -> None:
     state.training.guided_orders_placed += 1
     if below_op:
         state.training.guided_orders_below_op += 1
     level = active_level(state)
     if level is not None and "guided_order_below_lp_min" in level.win_conditions:
-        needed = int(level.win_conditions.get("guided_order_below_lp_item_min", 2))
-        if below_lp_count >= needed:
+        needed_op = int(level.win_conditions.get("guided_order_below_op_item_min", 0))
+        needed_lp = int(level.win_conditions.get("guided_order_below_lp_item_min", 2))
+        if below_op_count >= needed_op and below_lp_count >= needed_lp:
             state.training.guided_orders_below_lp += 1
 
 

--- a/src/imsim/ui/components.py
+++ b/src/imsim/ui/components.py
@@ -1596,17 +1596,25 @@ def build_inventory_table(state: SimulationState, theme: str = "light"):
         )
     selected_columns = visible_columns(state) or tuple(column_config.keys())
     compact_lesson_items = level is not None
-    compact_lesson_widths = {
-        "item": {"maxWidth": 76},
+    column_widths = {
+        "item": {"minWidth": 72, "maxWidth": 90},
         "on_hand": {"minWidth": 120},
         "on_order": {"minWidth": 124},
         "backorder": {"minWidth": 128},
         "pna": {"minWidth": 108},
         "op": {"minWidth": 96},
+        "lp": {"minWidth": 96},
+        "oq": {"minWidth": 96},
+        "eoq": {"minWidth": 96},
+        "soq": {"minWidth": 96},
         "usage_rate": {"minWidth": 112},
         "hits_per_month": {"minWidth": 96},
         "item_cost": {"minWidth": 96},
         "lead_time": {"minWidth": 120},
+        "standard_pack": {"minWidth": 112},
+        "safety_allowance": {"minWidth": 118},
+        "cp": {"minWidth": 96},
+        "surplus_line": {"minWidth": 168},
         "days_to_op": {"minWidth": 132},
         "daily_usage": {"minWidth": 128},
     }
@@ -1618,11 +1626,9 @@ def build_inventory_table(state: SimulationState, theme: str = "light"):
             column_def["headerTooltip"] = "Suggested order quantity."
         if key == "item":
             column_def["pinned"] = "left"
-            column_def["maxWidth"] = 90
         else:
             column_def["type"] = "numericColumn"
-        if compact_lesson_items:
-            column_def.update(compact_lesson_widths.get(key, {}))
+        column_def.update(column_widths.get(key, {}))
         column_defs.append(column_def)
     default_col_def = {"sortable": True, "filter": True, "resizable": True}
     dash_grid_options = {

--- a/src/imsim/ui/components.py
+++ b/src/imsim/ui/components.py
@@ -1595,11 +1595,7 @@ def build_inventory_table(state: SimulationState, theme: str = "light"):
             "No items loaded yet. Add an item or import a sample workbook.", color="secondary"
         )
     selected_columns = visible_columns(state) or tuple(column_config.keys())
-    compact_lesson_items = (
-        level is not None
-        and level.layout_variant in {"intro_pna", "workspace_basic"}
-        and level.index not in {11}
-    )
+    compact_lesson_items = level is not None
     compact_lesson_widths = {
         "item": {"maxWidth": 76},
         "on_hand": {"minWidth": 120},

--- a/tests/test_repository_and_app.py
+++ b/tests/test_repository_and_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -86,6 +87,28 @@ def test_file_repository_rejects_stale_save(test_config):
     state_two.day = 11
     with pytest.raises(SessionConflictError):
         repo_two.save("shared", state_two)
+
+
+def test_file_repository_retries_transient_replace_denial(test_config, monkeypatch):
+    repo = FileSessionRepository(test_config)
+    original_replace = os.replace
+    attempts = 0
+
+    def flaky_replace(source, target):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("temporarily locked")
+        original_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+
+    state = SimulationState()
+    state.day = 12
+    repo.save("flaky", state)
+
+    assert attempts == 2
+    assert repo.get_or_create("flaky").day == 12
 
 
 def test_database_repository_persists_state(tmp_path):

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -23,6 +23,7 @@ from imsim.services.training import (
     evaluate_active_lesson,
     final_academy_level,
     is_action_allowed,
+    record_guided_order,
     reset_progress_state,
     unlock_all_academy_levels,
 )
@@ -176,6 +177,7 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     intro_pna_grid = build_inventory_table(intro_pna_state)
     intro_pna_figure = build_inventory_figure(intro_pna_state)
     ranking_grid = build_inventory_table(ranking_state)
+    line_point_grid = build_inventory_table(line_point_state)
     review_cycle_figure = build_inventory_figure(review_cycle_state)
     line_point_figure = build_inventory_figure(line_point_state)
     signal_grid = build_inventory_table(signal_state)
@@ -192,11 +194,24 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     assert intro_pna_grid.dashGridOptions["domLayout"] == "autoHeight"
     assert intro_pna_figure.layout.height == 340
     assert isinstance(ranking_grid, AgGrid)
-    assert ranking_grid.style["height"] == "36rem"
+    assert ranking_grid.style["height"] == "auto"
+    assert ranking_grid.dashGridOptions["domLayout"] == "autoHeight"
+    assert isinstance(line_point_grid, AgGrid)
+    assert line_point_grid.style["height"] == "auto"
+    assert line_point_grid.dashGridOptions["domLayout"] == "autoHeight"
+    assert [column["field"] for column in line_point_grid.columnDefs] == [
+        "item",
+        "pna",
+        "op",
+        "lp",
+        "days_to_op",
+        "soq",
+    ]
     assert review_cycle_figure.layout.height == 340
     assert line_point_figure.layout.height == 340
     assert isinstance(signal_grid, AgGrid)
-    assert signal_grid.style["height"] == "32rem"
+    assert signal_grid.style["height"] == "auto"
+    assert signal_grid.dashGridOptions["domLayout"] == "autoHeight"
     assert signal_figure.layout.height == 300
     assert exception_figure.layout.height == 360
     assert certification_figure.layout.height == 360
@@ -204,6 +219,16 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     assert certification_figure.layout.meta["layout_signature"].startswith(
         "workspace_certification:items:"
     )
+
+
+def test_academy_lesson_inventory_grids_use_compact_height():
+    for level_index in range(1, 19):
+        state = build_level_state(f"level-{level_index}")
+        grid = build_inventory_table(state)
+
+        assert isinstance(grid, AgGrid)
+        assert grid.style["height"] == "auto"
+        assert grid.dashGridOptions["domLayout"] == "autoHeight"
 
 
 def test_level_seventeen_uses_exception_boundary_figure():
@@ -693,7 +718,8 @@ def test_line_point_and_exception_lessons_track_new_objectives():
     assert line_level is not None
     assert line_level.day_window == 40
     assert line_level.win_conditions == {
-        "guided_order_below_lp_item_min": 2,
+        "guided_order_below_op_item_min": 1,
+        "guided_order_below_lp_item_min": 3,
         "guided_order_below_lp_min": 2,
     }
     line_point.day = line_level.day_window + 1
@@ -702,7 +728,10 @@ def test_line_point_and_exception_lessons_track_new_objectives():
 
     assert evaluation is not None
     assert evaluation.passed is False
-    assert "Guided reorders while 2+ items below LP: 0/2" in evaluation.metric_rows
+    assert (
+        "Guided reorders while 1+ item below OP and 3+ total below LP: 0/2"
+        in evaluation.metric_rows
+    )
 
     line_point.training.guided_orders_below_lp = 1
     evaluation = evaluate_active_lesson(line_point)
@@ -727,6 +756,19 @@ def test_line_point_and_exception_lessons_track_new_objectives():
     assert evaluation.passed is True
     assert any("critical point" in row for row in evaluation.metric_rows)
     assert any("surplus threshold" in row for row in evaluation.metric_rows)
+
+
+def test_line_point_qualified_guided_reorder_requires_op_and_lp_signals():
+    state = build_level_state("level-13")
+
+    record_guided_order(state, below_op=True, below_op_count=1, below_lp_count=2)
+    assert state.training.guided_orders_below_lp == 0
+
+    record_guided_order(state, below_op=False, below_op_count=0, below_lp_count=3)
+    assert state.training.guided_orders_below_lp == 0
+
+    record_guided_order(state, below_op=True, below_op_count=1, below_lp_count=3)
+    assert state.training.guided_orders_below_lp == 1
 
 
 def test_final_lesson_pass_unlocks_simulator_reward():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -183,7 +183,9 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     signal_grid = build_inventory_table(signal_state)
     signal_figure = build_inventory_figure(signal_state)
     exception_figure = build_inventory_figure(exception_state)
+    certification_grid = build_inventory_table(certification_state)
     certification_figure = build_inventory_figure(certification_state)
+    simulator_grid = build_inventory_table(simulator_state)
     simulator_figure = build_inventory_figure(simulator_state)
 
     assert isinstance(basic_grid, AgGrid)
@@ -214,7 +216,17 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     assert signal_grid.dashGridOptions["domLayout"] == "autoHeight"
     assert signal_figure.layout.height == 300
     assert exception_figure.layout.height == 360
+    assert isinstance(certification_grid, AgGrid)
+    assert certification_grid.style["height"] == "auto"
+    assert certification_grid.dashGridOptions["domLayout"] == "autoHeight"
+    assert certification_grid.columnDefs[-1]["field"] == "soq"
+    assert certification_grid.columnDefs[-1]["minWidth"] == 96
     assert certification_figure.layout.height == 360
+    assert isinstance(simulator_grid, AgGrid)
+    assert simulator_grid.style["height"] == "28rem"
+    assert simulator_grid.dashGridOptions["pagination"] is True
+    assert simulator_grid.columnDefs[-1]["field"] == "soq"
+    assert simulator_grid.columnDefs[-1]["minWidth"] == 96
     assert simulator_figure.layout.height == 460
     assert certification_figure.layout.meta["layout_signature"].startswith(
         "workspace_certification:items:"

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -691,9 +691,26 @@ def test_line_point_and_exception_lessons_track_new_objectives():
     line_point = build_level_state("level-13")
     line_level = academy_level("level-13")
     assert line_level is not None
+    assert line_level.day_window == 40
+    assert line_level.win_conditions == {
+        "guided_order_below_lp_item_min": 2,
+        "guided_order_below_lp_min": 2,
+    }
     line_point.day = line_level.day_window + 1
-    line_point.training.guided_orders_placed = 1
 
+    evaluation = evaluate_active_lesson(line_point)
+
+    assert evaluation is not None
+    assert evaluation.passed is False
+    assert "Guided reorders while 2+ items below LP: 0/2" in evaluation.metric_rows
+
+    line_point.training.guided_orders_below_lp = 1
+    evaluation = evaluate_active_lesson(line_point)
+
+    assert evaluation is not None
+    assert evaluation.passed is False
+
+    line_point.training.guided_orders_below_lp = 2
     evaluation = evaluate_active_lesson(line_point)
 
     assert evaluation is not None


### PR DESCRIPTION
## Summary

This PR fixes the Level 13 win condition from Issue #24 and improves several planner grid layouts across the academy and simulator.

## Changes

- Updated Level 13 to use a more achievable and intentional objective:
  - 40 simulated days
  - Requires 2 qualifying guided reorders
  - A qualifying reorder requires 1 item below OP and 3 total items below LP
- Reworked Lesson 13 planner grid metrics to better support the LP decision:
  - PNA
  - OP
  - LP
  - Days to OP
  - SOQ
- Tightened academy inventory cards so planner grids no longer leave large blank areas.
- Improved simulator and Lesson 18 planner grid readability with better column sizing.
- Adjusted Lesson 18 and simulator layout so Visuals, Planner grid, and ASQ exception center use available width more effectively.
- Moved ASQ exception center below the planner grid and shortened it into a compact scrollable panel.
- Cleaned up spacing for the Lesson 18 Lesson snapshot, Costs, and Sales cards.

## Testing

- Ran focused training and UI refresh tests successfully.