### PR TITLE
fixed plot height; table formatting; rendering bug

### DIFF
--- a/assets/imsim.css
+++ b/assets/imsim.css
@@ -30,6 +30,7 @@
   --imsim-size-table-min: 53.75rem;
   --imsim-size-footer-width: 20rem;
   --imsim-size-dashboard-graph-min: 18rem;
+  --imsim-size-lesson-trend-graph-min: 21.25rem;
   --imsim-size-control-rail-max: 25rem;
   --imsim-size-dashboard-rail-max: 20rem;
   --imsim-size-dashboard-panel-max: 15rem;
@@ -1164,6 +1165,20 @@ body {
   box-shadow:
     inset 0 0 0 2px var(--imsim-blue),
     0 0 0 2px color-mix(in srgb, var(--imsim-blue) 18%, transparent);
+}
+
+.lesson-inventory-grid {
+  animation: imsim-grid-mount-settle 180ms step-end both;
+}
+
+@keyframes imsim-grid-mount-settle {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .exception-stack {
@@ -2807,8 +2822,20 @@ body {
   }
 
   .dashboard-shell.lesson-dashboard.lesson-level-1 #service-panel > .card,
-  .dashboard-shell.lesson-dashboard.lesson-level-1 #session-panel > .card {
+  .dashboard-shell.lesson-dashboard.lesson-level-1 #session-panel > .card,
+  .dashboard-shell.lesson-dashboard.lesson-level-1 #graph-panel > .card {
     height: 100%;
+  }
+
+  .dashboard-shell.lesson-dashboard.lesson-level-1 #graph-panel > .card > .card-body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .dashboard-shell.lesson-dashboard.lesson-level-1 #inventory-graph {
+    min-height: var(--imsim-size-lesson-trend-graph-min);
   }
 
   .dashboard-shell.lesson-dashboard.lesson-level-1 #session-panel .session-card {

--- a/src/imsim/callbacks/simulation.py
+++ b/src/imsim/callbacks/simulation.py
@@ -3,22 +3,62 @@ from __future__ import annotations
 import dash
 import dash_bootstrap_components as dbc
 from dash import Input, Output, State
+from dash import ctx as dash_ctx
 from dash.exceptions import PreventUpdate
 
 from ..models import default_state
 from ..services.simulation import tick_state
-from ..services.training import build_level_state, build_simulator_state
+from ..services.training import active_level, build_level_state, build_simulator_state
 from ..ui.components import (
     build_exception_center,
     build_inventory_table,
     build_kpi_strip,
     costs_card_children,
     inventory_graph_style,
+    lesson_compact_summary_children,
     refresh_inventory_figure,
     sales_card_children,
     service_card_children,
 )
 from .common import CallbackRegistrarContext
+
+
+def _status_label(state) -> str:
+    if state.is_initialized:
+        return "Status: Running"
+    if state.training.lesson_status == "passed":
+        return "Status: Lesson complete"
+    if state.training.lesson_status == "failed":
+        return "Status: Lesson failed"
+    return "Status: Ready" if state.training.current_view != "main_menu" else "Status: Academy menu"
+
+
+def _start_button_view(state, ctx: CallbackRegistrarContext) -> tuple[str, str, bool]:
+    terminal = ctx.lesson_terminal(state)
+    label, class_name = ctx.start_button_state(
+        state,
+        running=state.is_initialized,
+        disabled=terminal,
+        resumable=(
+            not state.is_initialized
+            and state.day > 1
+            and state.training.current_view != "main_menu"
+            and not terminal
+        ),
+    )
+    return label, class_name, terminal
+
+
+def _lesson_tick_session_revision(summary: dict[str, int], session_revision, ctx):
+    if summary.get("lesson_completed"):
+        return ctx.next_session_revision(session_revision)
+    return dash.no_update
+
+
+def _inventory_table_update(state, theme_name: str, triggered_id):
+    if triggered_id == "dashboard-tick" and active_level(state) is not None:
+        return dash.no_update
+    return build_inventory_table(state, theme_name)
 
 
 def register_simulation_callbacks(ctx: CallbackRegistrarContext) -> None:
@@ -37,13 +77,15 @@ def register_simulation_callbacks(ctx: CallbackRegistrarContext) -> None:
             Output("exception-center-shell", "children"),
         ],
         Input("user-data-store", "data"),
-        Input("session-revision", "data"),
+        Input("dashboard-layout-revision", "data"),
         Input("dashboard-tick", "data"),
         Input("theme-store", "data"),
         State("inventory-graph", "figure"),
         prevent_initial_call="initial_duplicate",
     )
-    def render_dashboard(client_data, _session_revision, _dashboard_tick, theme, current_figure):
+    def render_dashboard(
+        client_data, _dashboard_layout_revision, _dashboard_tick, theme, current_figure
+    ):
         session_id = (client_data or {}).get("uuid")
         state = ctx.repository.get_or_create(session_id) if session_id else default_state()
         theme_name = ctx.theme_name(theme)
@@ -55,12 +97,18 @@ def register_simulation_callbacks(ctx: CallbackRegistrarContext) -> None:
             costs_card_children(state),
             sales_card_children(state),
             build_kpi_strip(state),
-            build_inventory_table(state, theme_name),
+            _inventory_table_update(state, theme_name, dash_ctx.triggered_id),
             build_exception_center(state),
         )
 
     @app.callback(
         [
+            Output("day-display", "children", allow_duplicate=True),
+            Output("sim-status", "children", allow_duplicate=True),
+            Output("start-button", "children", allow_duplicate=True),
+            Output("start-button", "className", allow_duplicate=True),
+            Output("start-button", "disabled", allow_duplicate=True),
+            Output("lesson-compact-summary", "children", allow_duplicate=True),
             Output("dashboard-tick", "data", allow_duplicate=True),
             Output("session-revision", "data", allow_duplicate=True),
             Output("asq-apply-feedback", "children", allow_duplicate=True),
@@ -91,9 +139,36 @@ def register_simulation_callbacks(ctx: CallbackRegistrarContext) -> None:
             )
         next_tick = ctx.next_session_revision(dashboard_tick)
         interval_disabled = not state.is_initialized
+        start_label, start_class, start_disabled = _start_button_view(state, ctx)
+        immediate_ui = (
+            f"Day: {state.day}",
+            _status_label(state),
+            start_label,
+            start_class,
+            start_disabled,
+        )
+        compact_summary = (
+            dash.no_update
+            if state.training.current_view == "simulator"
+            else lesson_compact_summary_children(state)
+        )
         if state.training.current_view == "simulator":
-            return next_tick, dash.no_update, feedback, interval_disabled
-        return next_tick, ctx.next_session_revision(session_revision), feedback, interval_disabled
+            return (
+                *immediate_ui,
+                compact_summary,
+                next_tick,
+                dash.no_update,
+                feedback,
+                interval_disabled,
+            )
+        return (
+            *immediate_ui,
+            compact_summary,
+            next_tick,
+            _lesson_tick_session_revision(summary, session_revision, ctx),
+            feedback,
+            interval_disabled,
+        )
 
     @app.callback(
         Output("session-revision", "data", allow_duplicate=True),

--- a/src/imsim/callbacks/training.py
+++ b/src/imsim/callbacks/training.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
+import dash
 from dash import Input, Output, State, html
 from dash import ctx as dash_ctx
 from dash.exceptions import PreventUpdate
@@ -47,6 +51,44 @@ def scroll_reset_view_key(state) -> str:
     if state.training.current_view == "simulator":
         return f"simulator:{dashboard_shell_class_name(state)}"
     return state.training.current_view
+
+
+def _dashboard_refresh_signature(state) -> str:
+    dashboard_state = state.to_dict()
+    dashboard_state.pop("revision", None)
+    dashboard_state.pop("is_initialized", None)
+    training_state = dashboard_state.get("training")
+    if isinstance(training_state, dict):
+        for transient_key in (
+            "lesson_status",
+            "lesson_intro_dismissed",
+            "last_result_title",
+            "last_result_message",
+        ):
+            training_state.pop(transient_key, None)
+    payload = {
+        "dashboard_class": dashboard_shell_class_name(state),
+        "state": dashboard_state,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha1(encoded).hexdigest()
+
+
+def _dashboard_layout_revision_update(state, current_data, ctx: CallbackRegistrarContext):
+    revision = 0
+    current_signature = None
+    if isinstance(current_data, dict):
+        revision = int(current_data.get("revision") or 0)
+        current_signature = current_data.get("signature")
+    elif current_data is not None:
+        revision = int(current_data or 0)
+    next_signature = _dashboard_refresh_signature(state)
+    if current_signature == next_signature:
+        return dash.no_update
+    return {
+        "revision": ctx.next_session_revision(revision),
+        "signature": next_signature,
+    }
 
 
 def register_training_callbacks(ctx: CallbackRegistrarContext) -> None:
@@ -387,12 +429,14 @@ def register_training_callbacks(ctx: CallbackRegistrarContext) -> None:
             Output("academy-simulator-button", "disabled"),
             Output("advanced-sandbox-copy", "children"),
             Output("interval-component", "disabled", allow_duplicate=True),
+            Output("dashboard-layout-revision", "data"),
         ],
         Input("user-data-store", "data"),
         Input("session-revision", "data"),
+        State("dashboard-layout-revision", "data"),
         prevent_initial_call="initial_duplicate",
     )
-    def render_training_shells(client_data, _session_revision):
+    def render_training_shells(client_data, _session_revision, dashboard_layout_revision):
         state = ctx.current_state(client_data)
         panels = visible_panels(state)
         level = active_level(state)
@@ -534,6 +578,7 @@ def register_training_callbacks(ctx: CallbackRegistrarContext) -> None:
             not state.training.simulator_unlocked,
             sandbox_copy,
             interval_disabled,
+            _dashboard_layout_revision_update(state, dashboard_layout_revision, ctx),
         )
 
     @app.callback(

--- a/src/imsim/ui/figures.py
+++ b/src/imsim/ui/figures.py
@@ -194,6 +194,14 @@ def inventory_graph_height(state: SimulationState) -> int:
 
 def inventory_graph_style(state: SimulationState) -> dict[str, str]:
     height = inventory_graph_height(state)
+    level = active_level(state)
+    if level is not None and level.index == 1:
+        return {
+            "flex": "1 1 auto",
+            "height": "100%",
+            "minHeight": f"{height}px",
+            "width": "100%",
+        }
     return {"height": f"{height}px", "minHeight": f"{height}px", "width": "100%"}
 
 

--- a/src/imsim/ui/grids.py
+++ b/src/imsim/ui/grids.py
@@ -274,13 +274,18 @@ def build_inventory_table(state: SimulationState, theme: str = "light"):
         if level is not None and level.index in (2, 3, 6):
             min_height = "5rem"
         grid_style = {"height": "auto", "minHeight": min_height, "width": "100%"}
+    grid_props: dict[str, object] = {}
+    grid_props["columnSize"] = "responsiveSizeToFit" if compact_lesson_items else "sizeToFit"
+    class_name = _grid_theme_class(theme)
+    if compact_lesson_items:
+        class_name = f"{class_name} lesson-inventory-grid"
     return dag.AgGrid(
         id="inventory-table-grid",
         rowData=rows,
         columnDefs=column_defs,
         defaultColDef=default_col_def,
-        className=_grid_theme_class(theme),
-        columnSize="sizeToFit",
+        className=class_name,
         dashGridOptions=dash_grid_options,
         style=grid_style,
+        **grid_props,
     )

--- a/src/imsim/ui/layout.py
+++ b/src/imsim/ui/layout.py
@@ -23,6 +23,7 @@ def _stores_and_intervals(config: IMSimConfig) -> list:
         dcc.Store(id="upload-preview-data"),
         dcc.Store(id="theme-store", storage_type="local", data="light"),
         dcc.Store(id="session-revision", data=0),
+        dcc.Store(id="dashboard-layout-revision", data=0),
         dcc.Store(id="dashboard-tick", data=0),
         dcc.Store(id="view-scroll-store"),
         dcc.Store(id="view-scroll-sink"),

--- a/src/imsim/ui/layout_dashboard.py
+++ b/src/imsim/ui/layout_dashboard.py
@@ -308,6 +308,7 @@ def _graph_panel() -> html.Div:
                 figure={},
                 className="inventory-graph",
                 config=_GRAPH_CONFIG,
+                responsive=True,
             ),
         ],
     )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -207,6 +207,8 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     assert isinstance(basic_grid, AgGrid)
     assert basic_grid.style["height"] == "auto"
     assert basic_grid.dashGridOptions["domLayout"] == "autoHeight"
+    assert basic_grid.columnSize == "responsiveSizeToFit"
+    assert "lesson-inventory-grid" in basic_grid.className
     assert isinstance(intro_pna_grid, AgGrid)
     assert intro_pna_grid.style["height"] == "auto"
     assert intro_pna_grid.dashGridOptions["domLayout"] == "autoHeight"
@@ -241,6 +243,7 @@ def test_workspace_variants_drive_figure_and_grid_sizes():
     assert isinstance(simulator_grid, AgGrid)
     assert simulator_grid.style["height"] == "28rem"
     assert simulator_grid.dashGridOptions["pagination"] is True
+    assert simulator_grid.columnSize == "sizeToFit"
     assert simulator_grid.columnDefs[-1]["field"] == "soq"
     assert simulator_grid.columnDefs[-1]["minWidth"] == 96
     assert simulator_figure.layout.height == 460
@@ -277,9 +280,16 @@ def test_level_seventeen_uses_exception_boundary_figure():
 
 
 def test_inventory_graph_style_tracks_figure_height():
+    intro_state = build_level_state("level-1")
     lesson_state = build_level_state("level-2")
     simulator_state = build_simulator_state()
 
+    assert inventory_graph_style(intro_state) == {
+        "flex": "1 1 auto",
+        "height": "100%",
+        "minHeight": "340px",
+        "width": "100%",
+    }
     assert inventory_graph_style(lesson_state) == {
         "height": "392px",
         "minHeight": "392px",

--- a/tests/test_ui_refresh_callbacks.py
+++ b/tests/test_ui_refresh_callbacks.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import dash
+from dash_ag_grid import AgGrid
+
 import imsim.ui.components as ui_components
-from imsim.callbacks.training import dashboard_shell_class_name
-from imsim.services.training import build_level_state
+from imsim.callbacks.simulation import _inventory_table_update, _lesson_tick_session_revision
+from imsim.callbacks.training import (
+    _dashboard_layout_revision_update,
+    dashboard_shell_class_name,
+)
+from imsim.services.training import build_level_state, build_simulator_state
 
 
 def _walk_components(component):
@@ -79,10 +86,11 @@ def test_layout_keeps_callback_target_ids(dash_app):
         "inventory-table-shell",
         "custom-order-grid",
         "po-overview-grid",
+        "dashboard-layout-revision",
     } <= component_ids
 
 
-def test_dashboard_render_listens_to_session_revision_and_theme(dash_app):
+def test_dashboard_render_waits_for_dashboard_layout_revision(dash_app):
     spec = _find_callback(
         dash_app,
         [
@@ -95,10 +103,50 @@ def test_dashboard_render_listens_to_session_revision_and_theme(dash_app):
     )
     assert _input_pairs(spec) == {
         ("user-data-store", "data"),
-        ("session-revision", "data"),
+        ("dashboard-layout-revision", "data"),
         ("dashboard-tick", "data"),
         ("theme-store", "data"),
     }
+
+
+def test_running_lesson_tick_does_not_rebuild_training_shell():
+    class RevisionContext:
+        def next_session_revision(self, revision):
+            return int(revision or 0) + 1
+
+    ctx = RevisionContext()
+
+    assert _lesson_tick_session_revision({"lesson_completed": 0}, 7, ctx) is dash.no_update
+    assert _lesson_tick_session_revision({"lesson_completed": 1}, 7, ctx) == 8
+
+
+def test_lesson_dashboard_tick_does_not_touch_inventory_grid():
+    state = build_level_state("level-3")
+    simulator_state = build_simulator_state()
+
+    initial_table = _inventory_table_update(state, "light", "dashboard-layout-revision")
+    lesson_tick = _inventory_table_update(state, "light", "dashboard-tick")
+    simulator_tick = _inventory_table_update(simulator_state, "light", "dashboard-tick")
+
+    assert isinstance(initial_table, AgGrid)
+    assert lesson_tick is dash.no_update
+    assert isinstance(simulator_tick, AgGrid)
+
+
+def test_interval_tick_updates_terminal_lesson_controls_immediately(dash_app):
+    spec = _find_callback(
+        dash_app,
+        [
+            ("day-display", "children"),
+            ("sim-status", "children"),
+            ("start-button", "children"),
+            ("start-button", "className"),
+            ("start-button", "disabled"),
+            ("lesson-compact-summary", "children"),
+            ("interval-component", "disabled"),
+        ],
+    )
+    assert _input_pairs(spec) == {("interval-component", "n_intervals")}
 
 
 def test_training_shell_render_listens_to_session_revision(dash_app):
@@ -109,12 +157,33 @@ def test_training_shell_render_listens_to_session_revision(dash_app):
             ("lesson-shell", "style"),
             ("dashboard-shell", "className"),
             ("interval-component", "disabled"),
+            ("dashboard-layout-revision", "data"),
         ],
     )
     assert _input_pairs(spec) == {
         ("user-data-store", "data"),
         ("session-revision", "data"),
     }
+
+
+def test_dashboard_layout_revision_ignores_start_only_changes():
+    class RevisionContext:
+        def next_session_revision(self, revision):
+            return int(revision or 0) + 1
+
+    ctx = RevisionContext()
+    state = build_level_state("level-3")
+    initial_revision = _dashboard_layout_revision_update(state, 0, ctx)
+
+    state.is_initialized = True
+    state.training.lesson_status = "running"
+
+    assert _dashboard_layout_revision_update(state, initial_revision, ctx) is dash.no_update
+
+    state.day = 2
+
+    changed_revision = _dashboard_layout_revision_update(state, initial_revision, ctx)
+    assert changed_revision["revision"] == initial_revision["revision"] + 1
 
 
 def test_page_lifecycle_changes_refresh_session_state(dash_app):


### PR DESCRIPTION
Fixed a couple bugs:

- Plot height varied when running/clicking on lesson sometimes due to mismatched sizing across Python and CSS, now reconciled and fixed
- Table would re-size after every refresh/tick, now fixed
- Days would sometimes not refresh/tick nearing the end of the lesson, browser refresh not properly working (didn't encounter before changing plot height?  Not sure if Dash/new ui bug or I caused it); should be fixed.  